### PR TITLE
Added .preload class to main.css, that stop animation transition; add…

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -81,3 +81,11 @@
 body {
  font-family: 'Roboto', sans-serif;
 }
+
+
+/**
+* transitions only after page load
+*/
+.preload * {
+ transition: none !important;
+}

--- a/assets/js/removePreloadClass.js
+++ b/assets/js/removePreloadClass.js
@@ -1,0 +1,6 @@
+/**
+ * src: https://css-tricks.com/transitions-only-after-page-load/
+ * */
+window.onload = function () {
+ document.getElementsByTagName('body')[0].classList.remove('preload');
+};


### PR DESCRIPTION
Не вызывать анимацию при первой загрузке страницы:
Добавил класс `.preload` в `main.css`.
Добавил скрипт `assets/js/removePreloadClass.js`, который удаляет `.preload` при загрузке страницы.
Повешу класс на `body` и подключу скрипт на странице с решением по анимации чекбокса (пока не решено).